### PR TITLE
from is a string and using count() throws error

### DIFF
--- a/class.mailer.php
+++ b/class.mailer.php
@@ -64,7 +64,7 @@ class Message {
 	public function send() {
 		$headers = "";
 
-		if (count($this->from) < 1) {
+		if (empty($this->from)) {
 			throw new \Exception('You forgot to addFrom();');
 		}
 


### PR DESCRIPTION
Should use `empty` check on `$this->from` since it is a string not array. PHP 7 throws